### PR TITLE
fix: article text alignment as justify

### DIFF
--- a/_sass/_patch.scss
+++ b/_sass/_patch.scss
@@ -22,6 +22,10 @@ article blockquote::before {
   content: "";
 }
 
+article p {
+    text-align: justify;
+}
+
 hr {
   margin-bottom: 2rem;
   margin-top: 2rem;


### PR DESCRIPTION
<h2 align="center">Before</h2>

![before](https://i.imgur.com/O7WcbwV.png)

---

<h2 align="center">After</h2>

![after](https://i.imgur.com/CufcW74.png)