### PR TITLE
fix: build workflow badge route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tech @ Skit
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/skit-ai/tech/github%20pages?style=flat-square)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/skit-ai/tech/github-pages.yml?branch=master&style=flat-square)
 
 This is source for the [tech team webpage][tech_blog] at Skit. Template is [Mundana by WowThemes.net][mundana]
 


### PR DESCRIPTION
This fixes the breaking change introduced by shields (relevant issue at https://github.com/badges/shields/issues/8671)